### PR TITLE
Update solr.cmd for round #1 migration to SolrCLI

### DIFF
--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -241,32 +241,11 @@ REM Only allow the command to be the first argument, assume start if not supplie
 IF "%1"=="start" goto set_script_cmd
 IF "%1"=="stop" goto set_script_cmd
 IF "%1"=="restart" goto set_script_cmd
-IF "%1"=="healthcheck" (
-  REM healthcheck uses different arg parsing strategy
-  set SCRIPT_CMD=healthcheck
-  SHIFT
-  goto parse_healthcheck_args
-)
-IF "%1"=="create" (
-  set SCRIPT_CMD=create
-  SHIFT
-  goto parse_create_args
-)
-IF "%1"=="create_core" (
-  set SCRIPT_CMD=create_core
-  SHIFT
-  goto parse_create_args
-)
-IF "%1"=="create_collection" (
-  set SCRIPT_CMD=create_collection
-  SHIFT
-  goto parse_create_args
-)
-IF "%1"=="delete" (
-  set SCRIPT_CMD=delete
-  SHIFT
-  goto parse_delete_args
-)
+IF "%1"=="healthcheck" goto run_solrcli
+IF "%1"=="create" goto run_solrcli
+IF "%1"=="create_core" goto run_solrcli
+IF "%1"=="create_collection" goto run_solrcli
+IF "%1"=="delete" goto run_solrcli
 IF "%1"=="zk" (
   set SCRIPT_CMD=zk
   SHIFT
@@ -278,13 +257,7 @@ IF "%1"=="auth" (
   SHIFT
   goto run_auth
 )
-IF "%1"=="config" (
-  REM config uses different arg parsing strategy
-  set SCRIPT_CMD=config
-  SHIFT
-  set CONFIG_ARGS=
-  goto parse_config_args
-)
+IF "%1"=="config" goto run_solrcli
 
 goto parse_args
 
@@ -299,11 +272,11 @@ IF "%FIRST_ARG%"=="/?" goto script_usage
 IF "%SCRIPT_CMD%"=="start" goto start_usage
 IF "%SCRIPT_CMD%"=="restart" goto start_usage
 IF "%SCRIPT_CMD%"=="stop" goto stop_usage
-IF "%SCRIPT_CMD%"=="healthcheck" goto healthcheck_usage
-IF "%SCRIPT_CMD%"=="create" goto create_usage
-IF "%SCRIPT_CMD%"=="create_core" goto create_core_usage
-IF "%SCRIPT_CMD%"=="create_collection" goto create_collection_usage
-IF "%SCRIPT_CMD%"=="delete" goto delete_usage
+IF "%SCRIPT_CMD%"=="healthcheck" goto run_solrcli
+IF "%SCRIPT_CMD%"=="create" goto run_solrcli
+IF "%SCRIPT_CMD%"=="create_core" goto run_solrcli
+IF "%SCRIPT_CMD%"=="create_collection" goto run_solrcli
+IF "%SCRIPT_CMD%"=="delete" goto run_solrcli
 IF  "%SCRIPT_CMD%"=="zk" goto zk_usage
 IF "%SCRIPT_CMD%"=="auth" goto auth_usage
 IF "%SCRIPT_CMD%"=="status" goto status_usage
@@ -414,128 +387,6 @@ goto done
 @echo.
 @echo  NOTE: To see if any Solr servers are running, do: solr status
 @echo.
-goto done
-
-:healthcheck_usage
-@echo.
-@echo Usage: solr healthcheck [-c collection] [-z zkHost] [-V]
-@echo.
-@echo Can be run from remote (non-Solr^) hosts, as long as a proper ZooKeeper connection is provided
-@echo.
-@echo   -c collection  Collection to run healthcheck against.
-@echo.
-@echo   -z zkHost      Zookeeper connection string; unnecessary if ZK_HOST is defined in solr.in.cmd;
-@echo                    otherwise, default is localhost:9983
-@echo.
-@echo   -V             Enable more verbose output
-@echo.
-goto done
-
-:create_usage
-echo.
-echo Usage: solr create [-c name] [-d confdir] [-n confname] [-shards #] [-replicationFactor #] [-p port] [-V]
-echo.
-echo   Create a core or collection depending on whether Solr is running in standalone (core) or SolrCloud
-echo   mode (collection). In other words, this action detects which mode Solr is running in, and then takes
-echo   the appropriate action (either create_core or create_collection). For detailed usage instructions, do:
-echo.
-echo     bin\solr create_core -help
-echo.
-echo        or
-echo.
-echo     bin\solr create_collection -help
-echo.
-goto done
-
-:delete_usage
-echo.
-echo Usage: solr delete [-c name] [-deleteConfig true^|false] [-p port] [-V]
-echo.
-echo  Deletes a core or collection depending on whether Solr is running in standalone (core) or SolrCloud
-echo  mode (collection). If you're deleting a collection in SolrCloud mode, the default behavior is to also
-echo  delete the configuration directory from Zookeeper so long as it is not being used by another collection.
-echo  You can override this behavior by passing -deleteConfig false when running this command.
-echo.
-echo  Can be run on remote (non-Solr^) hosts, as long as a valid SOLR_HOST is provided in solr.in.cmd
-echo.
-echo   -c name     Name of core to delete
-echo.
-echo   -deleteConfig boolean Delete the configuration directory from Zookeeper; default is true
-echo.
-echo   -p port     Port of a local Solr instance where you want to delete the core/collection
-echo                 If not specified, the script will search the local system for a running
-echo                 Solr instance and will use the port of the first server it finds.
-echo.
-echo   -V            Enables more verbose output.
-echo.
-goto done
-
-:create_core_usage
-echo.
-echo Usage: solr create_core [-c ^<core^>] [-d confdir] [-p port] [-V]
-echo.
-echo When a configSet is used, this can be run from any host.  If pointing at a non-configSet directory, this
-echo must be run from the host that you wish to create the core on.
-echo.
-echo   -c ^<core^>     Name of core to create
-echo.
-echo   -d confdir  Configuration directory to copy when creating the new core, built-in options are:
-echo.
-echo       _default: Minimal configuration, which supports enabling/disabling field-guessing support
-echo       sample_techproducts_configs: Example configuration with many optional features enabled to
-echo          demonstrate the full power of Solr
-echo.
-echo       If not specified, default is: _default
-echo.
-echo       Alternatively, you can pass the path to your own configuration directory instead of using
-echo       one of the built-in configurations, such as: bin\solr create_core -c mycore -d c:/tmp/myconfig
-echo.
-echo   -p port     Port of a local Solr instance where you want to create the new core
-echo                 If not specified, the script will search the local system for a running
-echo                 Solr instance and will use the port of the first server it finds.
-echo.
-echo   -V            Enable more verbose output.
-echo.
-goto done
-
-:create_collection_usage
-echo.
-echo Usage: solr create_collection [-c collection] [-d confdir] [-n confname] [-shards #] [-replicationFactor #] [-p port] [-V]
-echo.
-echo Can be run from remote (non-Solr^) hosts, as long as a valid SOLR_HOST is provided in solr.in.cmd.
-echo.
-echo   -c ^<collection^>         Name of collection to create
-echo.
-echo   -d ^<confdir^>            Configuration directory to copy when creating the new collection, built-in options are:
-echo.
-echo       _default: Minimal configuration, which supports enabling/disabling field-guessing support
-echo       sample_techproducts_configs: Example configuration with many optional features enabled to
-echo          demonstrate the full power of Solr
-echo.
-echo       If not specified, default is: _default
-echo.
-echo       Alternatively, you can pass the path to your own configuration directory instead of using
-echo       one of the built-in configurations, such as: bin\solr create_collection -c mycoll -d c:/tmp/myconfig
-echo.
-echo       By default the script will upload the specified confdir directory into Zookeeper using the same
-echo         name as the collection (-c) option. Alternatively, if you want to reuse an existing directory
-echo         or create a confdir in Zookeeper that can be shared by multiple collections, use the -n option
-echo.
-echo   -n configName         Name the configuration directory in Zookeeper; by default, the configuration
-echo                             will be uploaded to Zookeeper using the collection name (-c), but if you want
-echo                             to use an existing directory or override the name of the configuration in
-echo                              Zookeeper, then use the -c option.
-echo.
-echo   -shards #             Number of shards to split the collection into; default is 1
-echo.
-echo   -replicationFactor #  Number of copies of each document in the collection, default is 1 (no replication)
-echo.
-echo   -p port               Port of a local Solr instance where you want to create the new collection
-echo                           If not specified, the script will search the local system for a running
-echo                           Solr instance and will use the port of the first server it finds.
-echo.
-echo   -V                    Enable more verbose output.
-echo.
 goto done
 
 :zk_usage
@@ -1438,7 +1289,7 @@ IF "%FG%"=="1" (
   "%JAVA%" %SOLR_SSL_OPTS% %AUTHC_OPTS% %SOLR_ZK_CREDS_AND_ACLS% -Dsolr.install.dir="%SOLR_TIP%" -Dsolr.default.confdir="%DEFAULT_CONFDIR%"^
     -Dlog4j.configurationFile="file:///%DEFAULT_SERVER_DIR%\resources\log4j2-console.xml" ^
     -classpath "%DEFAULT_SERVER_DIR%\solr-webapp\webapp\WEB-INF\lib\*;%DEFAULT_SERVER_DIR%\lib\ext\*" ^
-    org.apache.solr.cli.SolrCLI status -maxWaitSecs !SOLR_START_WAIT! -solr !SOLR_URL_SCHEME!://%SOLR_TOOL_HOST%:%SOLR_PORT%/solr
+    org.apache.solr.cli.SolrCLI status -maxWaitSecs !SOLR_START_WAIT! -solrUrl !SOLR_URL_SCHEME!://%SOLR_TOOL_HOST%:%SOLR_PORT%/solr
   IF NOT "!ERRORLEVEL!"=="0" (
       set "SCRIPT_ERROR=Solr did not start or was not reachable. Check the logs for errors."
       goto err
@@ -1476,7 +1327,7 @@ for /f "usebackq" %%i in (`dir /b "%SOLR_TIP%\bin" ^| findstr /i "^solr-.*\.port
           "%JAVA%" %SOLR_SSL_OPTS% %AUTHC_OPTS% %SOLR_ZK_CREDS_AND_ACLS% -Dsolr.install.dir="%SOLR_TIP%" ^
             -Dlog4j.configurationFile="file:///%DEFAULT_SERVER_DIR%\resources\log4j2-console.xml" ^
             -classpath "%DEFAULT_SERVER_DIR%\solr-webapp\webapp\WEB-INF\lib\*;%DEFAULT_SERVER_DIR%\lib\ext\*" ^
-            org.apache.solr.cli.SolrCLI status -solr !SOLR_URL_SCHEME!://%SOLR_TOOL_HOST%:!SOME_SOLR_PORT!/solr
+            org.apache.solr.cli.SolrCLI status -solrUrl !SOLR_URL_SCHEME!://%SOLR_TOOL_HOST%:!SOME_SOLR_PORT!/solr
           @echo.
         )
       )
@@ -1485,47 +1336,6 @@ for /f "usebackq" %%i in (`dir /b "%SOLR_TIP%\bin" ^| findstr /i "^solr-.*\.port
 )
 if NOT "!has_info!"=="1" echo No running Solr nodes found.
 set has_info=
-goto done
-
-:parse_healthcheck_args
-IF [%1]==[] goto run_healthcheck
-IF "%1"=="-V" goto set_healthcheck_verbose
-IF "%1"=="-c" goto set_healthcheck_collection
-IF "%1"=="-collection" goto set_healthcheck_collection
-IF "%1"=="-z" goto set_healthcheck_zk
-IF "%1"=="-zkhost" goto set_healthcheck_zk
-IF "%1"=="-zkHost" goto set_healthcheck_zk
-IF "%1"=="-help" goto usage
-IF "%1"=="-usage" goto usage
-IF "%1"=="/?" goto usage
-goto run_healthcheck
-
-:set_healthcheck_verbose
-set HEALTHCHECK_VERBOSE="-verbose"
-SHIFT
-goto parse_healthcheck_args
-
-:set_healthcheck_collection
-set HEALTHCHECK_COLLECTION=%~2
-SHIFT
-SHIFT
-goto parse_healthcheck_args
-
-:set_healthcheck_zk
-set ZK_HOST=%~2
-SHIFT
-SHIFT
-goto parse_healthcheck_args
-
-:run_healthcheck
-IF NOT DEFINED HEALTHCHECK_COLLECTION goto healthcheck_usage
-IF NOT DEFINED HEALTHCHECK_VERBOSE set "HEALTHCHECK_VERBOSE="
-IF NOT DEFINED HEALTHCHECK_ZK_HOST set "HEALTHCHECK_ZK_HOST=localhost:9983"
-echo ZK_HOST: !ZK_HOST!
-"%JAVA%" %SOLR_SSL_OPTS% %AUTHC_OPTS% %SOLR_ZK_CREDS_AND_ACLS% -Dsolr.install.dir="%SOLR_TIP%" ^
-  -Dlog4j.configurationFile="file:///%DEFAULT_SERVER_DIR%\resources\log4j2-console.xml" ^
-  -classpath "%DEFAULT_SERVER_DIR%\solr-webapp\webapp\WEB-INF\lib\*;%DEFAULT_SERVER_DIR%\lib\ext\*" ^
-  org.apache.solr.cli.SolrCLI healthcheck -collection !HEALTHCHECK_COLLECTION! -zkHost !ZK_HOST! %HEALTHCHECK_VERBOSE%
 goto done
 
 :run_solrcli
@@ -1561,210 +1371,11 @@ SHIFT
 SHIFT
 goto parse_config_args
 
-:run_config
-IF NOT "!ZK_HOST!"=="" SET "CONFIG_ARGS=!CONFIG_ARGS! -z !ZK_HOST!"
-IF NOT "!SOLR_URL_SCHEME!"=="" SET "CONFIG_ARGS=!CONFIG_ARGS! -scheme !SOLR_URL_SCHEME!"
-
-"%JAVA%" %SOLR_SSL_OPTS% %AUTHC_OPTS% %SOLR_ZK_CREDS_AND_ACLS% -Dsolr.install.dir="%SOLR_TIP%" ^
-  -Dlog4j.configurationFile="file:///%DEFAULT_SERVER_DIR%\resources\log4j2-console.xml" ^
-  -classpath "%DEFAULT_SERVER_DIR%\solr-webapp\webapp\WEB-INF\lib\*;%DEFAULT_SERVER_DIR%\lib\ext\*" ^
-  org.apache.solr.cli.SolrCLI config !CONFIG_ARGS!
-if errorlevel 1 (
-   exit /b 1
-)
-goto done
-
 :get_version
 "%JAVA%" %SOLR_SSL_OPTS% %AUTHC_OPTS% %SOLR_ZK_CREDS_AND_ACLS% -Dsolr.install.dir="%SOLR_TIP%" ^
   -Dlog4j.configurationFile="file:///%DEFAULT_SERVER_DIR%\resources\log4j2-console.xml" ^
   -classpath "%DEFAULT_SERVER_DIR%\solr-webapp\webapp\WEB-INF\lib\*;%DEFAULT_SERVER_DIR%\lib\ext\*" ^
   org.apache.solr.cli.SolrCLI version
-goto done
-
-:parse_create_args
-IF [%1]==[] goto run_create
-IF "%1"=="-V" goto set_create_verbose
-IF "%1"=="-c" goto set_create_name
-IF "%1"=="-core" goto set_create_name
-IF "%1"=="-collection" goto set_create_name
-IF "%1"=="-d" goto set_create_confdir
-IF "%1"=="-confdir" goto set_create_confdir
-IF "%1"=="-n" goto set_create_confname
-IF "%1"=="-confname" goto set_create_confname
-IF "%1"=="-s" goto set_create_shards
-IF "%1"=="-shards" goto set_create_shards
-IF "%1"=="-rf" goto set_create_rf
-IF "%1"=="-replicationFactor" goto set_create_rf
-IF "%1"=="-p" goto set_create_port
-IF "%1"=="-port" goto set_create_port
-IF "%1"=="-help" goto usage
-IF "%1"=="-usage" goto usage
-IF "%1"=="/?" goto usage
-goto run_create
-
-
-:set_create_verbose
-set CREATE_VERBOSE="-verbose"
-SHIFT
-goto parse_create_args
-
-:set_create_name
-set CREATE_NAME=%~2
-SHIFT
-SHIFT
-goto parse_create_args
-
-:set_create_confdir
-set CREATE_CONFDIR=%~2
-SHIFT
-SHIFT
-goto parse_create_args
-
-:set_create_confname
-set CREATE_CONFNAME=%~2
-SHIFT
-SHIFT
-goto parse_create_args
-
-:set_create_port
-set CREATE_PORT=%~2
-SHIFT
-SHIFT
-goto parse_create_args
-
-:set_create_shards
-set CREATE_NUM_SHARDS=%~2
-SHIFT
-SHIFT
-goto parse_create_args
-
-:set_create_rf
-set CREATE_REPFACT=%~2
-SHIFT
-SHIFT
-goto parse_create_args
-
-:run_create
-IF "!CREATE_NAME!"=="" (
-  set "SCRIPT_ERROR=Name (-c) is a required parameter for %SCRIPT_CMD%"
-  goto invalid_cmd_line
-)
-IF NOT DEFINED CREATE_VERBOSE set "CREATE_VERBOSE="
-IF "!CREATE_CONFDIR!"=="" set CREATE_CONFDIR=_default
-IF "!CREATE_NUM_SHARDS!"=="" set CREATE_NUM_SHARDS=1
-IF "!CREATE_REPFACT!"=="" set CREATE_REPFACT=1
-IF "!CREATE_CONFNAME!"=="" set CREATE_CONFNAME=!CREATE_NAME!
-
-REM Find a port that Solr is running on
-if "!CREATE_PORT!"=="" (
-  for /f "usebackq" %%i in (`dir /b "%SOLR_TIP%\bin" ^| findstr /i "^solr-.*\.port$"`) do (
-    set SOME_SOLR_PORT=
-    For /F "Delims=" %%J In ('type "%SOLR_TIP%\bin\%%i"') do set SOME_SOLR_PORT=%%~J
-    if NOT "!SOME_SOLR_PORT!"=="" (
-      for /f "tokens=2,5" %%j in ('netstat -aon ^| find "TCP " ^| find ":0 " ^| find ":!SOME_SOLR_PORT! "') do (
-        IF NOT "%%k"=="0" set CREATE_PORT=!SOME_SOLR_PORT!
-      )
-    )
-  )
-)
-if "!CREATE_PORT!"=="" (
-  set "SCRIPT_ERROR=Could not find a running Solr instance on this host! Please use the -p option to specify the port."
-  goto err
-)
-
-if "!CREATE_CONFDIR!"=="_default" (
-  echo WARNING: Using _default configset with data driven schema functionality. NOT RECOMMENDED for production use.
-  echo          To turn off: bin\solr config -c !CREATE_NAME! -p !CREATE_PORT! -action set-user-property -property update.autoCreateFields -value false
-)
-
-if "%SCRIPT_CMD%"=="create_core" (
-  "%JAVA%" %SOLR_SSL_OPTS% %AUTHC_OPTS% %SOLR_ZK_CREDS_AND_ACLS% -Dsolr.install.dir="%SOLR_TIP%" ^
-    -Dlog4j.configurationFile="file:///%DEFAULT_SERVER_DIR%\resources\log4j2-console.xml" ^
-    -classpath "%DEFAULT_SERVER_DIR%\solr-webapp\webapp\WEB-INF\lib\*;%DEFAULT_SERVER_DIR%\lib\ext\*" ^
-    org.apache.solr.cli.SolrCLI create_core -name !CREATE_NAME! -solrUrl !SOLR_URL_SCHEME!://%SOLR_TOOL_HOST%:!CREATE_PORT!/solr ^
-    -confdir !CREATE_CONFDIR! -configsetsDir "%SOLR_TIP%\server\solr\configsets" %CREATE_VERBOSE%
-) else (
-  "%JAVA%" %SOLR_SSL_OPTS% %AUTHC_OPTS% %SOLR_ZK_CREDS_AND_ACLS% -Dsolr.install.dir="%SOLR_TIP%" -Dsolr.default.confdir="%DEFAULT_CONFDIR%"^
-    -Dlog4j.configurationFile="file:///%DEFAULT_SERVER_DIR%\resources\log4j2-console.xml" ^
-    -classpath "%DEFAULT_SERVER_DIR%\solr-webapp\webapp\WEB-INF\lib\*;%DEFAULT_SERVER_DIR%\lib\ext\*" ^
-    org.apache.solr.cli.SolrCLI create -name !CREATE_NAME! -shards !CREATE_NUM_SHARDS! -replicationFactor !CREATE_REPFACT! ^
-    -confname !CREATE_CONFNAME! -confdir !CREATE_CONFDIR! -configsetsDir "%SOLR_TIP%\server\solr\configsets" ^
-    -solrUrl !SOLR_URL_SCHEME!://%SOLR_TOOL_HOST%:!CREATE_PORT!/solr %CREATE_VERBOSE%
-)
-
-goto done
-
-:parse_delete_args
-IF [%1]==[] goto run_delete
-IF "%1"=="-V" goto set_delete_verbose
-IF "%1"=="-c" goto set_delete_name
-IF "%1"=="-core" goto set_delete_name
-IF "%1"=="-collection" goto set_delete_name
-IF "%1"=="-p" goto set_delete_port
-IF "%1"=="-port" goto set_delete_port
-IF "%1"=="-deleteConfig" goto set_delete_config
-IF "%1"=="-help" goto usage
-IF "%1"=="-usage" goto usage
-IF "%1"=="/?" goto usage
-goto run_delete
-
-:set_delete_verbose
-set DELETE_VERBOSE="-verbose"
-SHIFT
-goto parse_delete_args
-
-:set_delete_name
-set DELETE_NAME=%~2
-SHIFT
-SHIFT
-goto parse_delete_args
-
-:set_delete_port
-set DELETE_PORT=%~2
-SHIFT
-SHIFT
-goto parse_delete_args
-
-:set_delete_config
-set DELETE_CONFIG=%~2
-SHIFT
-SHIFT
-goto parse_delete_args
-
-:run_delete
-IF NOT DEFINED DELETE_VERBOSE set "DELETE_VERBOSE="
-IF "!DELETE_NAME!"=="" (
-  set "SCRIPT_ERROR=Name (-c) is a required parameter for %SCRIPT_CMD%"
-  goto invalid_cmd_line
-)
-
-REM Find a port that Solr is running on
-if "!DELETE_PORT!"=="" (
-  for /f "usebackq" %%i in (`dir /b "%SOLR_TIP%\bin" ^| findstr /i "^solr-.*\.port$"`) do (
-    set SOME_SOLR_PORT=
-    For /F "Delims=" %%J In ('type "%SOLR_TIP%\bin\%%i"') do set SOME_SOLR_PORT=%%~J
-    if NOT "!SOME_SOLR_PORT!"=="" (
-      for /f "tokens=2,5" %%j in ('netstat -aon ^| find "TCP " ^| find ":0 " ^| find ":!SOME_SOLR_PORT! "') do (
-        IF NOT "%%k"=="0" set DELETE_PORT=!SOME_SOLR_PORT!
-      )
-    )
-  )
-)
-if "!DELETE_PORT!"=="" (
-  set "SCRIPT_ERROR=Could not find a running Solr instance on this host! Please use the -p option to specify the port."
-  goto err
-)
-
-if "!DELETE_CONFIG!"=="" (
-  set DELETE_CONFIG=true
-)
-
-"%JAVA%" %SOLR_SSL_OPTS% %AUTHC_OPTS% %SOLR_ZK_CREDS_AND_ACLS% -Dsolr.install.dir="%SOLR_TIP%" ^
--Dlog4j.configurationFile="file:///%DEFAULT_SERVER_DIR%\resources\log4j2-console.xml" ^
--classpath "%DEFAULT_SERVER_DIR%\solr-webapp\webapp\WEB-INF\lib\*;%DEFAULT_SERVER_DIR%\lib\ext\*" ^
-org.apache.solr.cli.SolrCLI delete -name !DELETE_NAME! -deleteConfig !DELETE_CONFIG! ^
--solrUrl !SOLR_URL_SCHEME!://%SOLR_TOOL_HOST%:!DELETE_PORT!/solr %DELETE_VERBOSE%
-
 goto done
 
 REM Clumsy to do the state machine thing for -d and -n, but that's required for back-compat
@@ -2043,13 +1654,13 @@ IF "%FIRST_ARG%"=="start" (
 ) ELSE IF "%FIRST_ARG%"=="stop" (
   goto stop_usage
 ) ELSE IF "%FIRST_ARG%"=="healthcheck" (
-  goto healthcheck_usage
+  goto run_solrcli
 ) ELSE IF "%FIRST_ARG%"=="create" (
-  goto create_usage
+  goto run_solrcli
 ) ELSE IF "%FIRST_ARG%"=="create_core" (
-  goto create_core_usage
+  goto run_solrcli
 ) ELSE IF "%FIRST_ARG%"=="create_collection" (
-  goto create_collection_usage
+  goto run_solrcli
 ) ELSE IF "%FIRST_ARG%"=="zk" (
   goto zk_short_usage
 ) ELSE IF "%FIRST_ARG%"=="auth" (

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -316,9 +316,9 @@ goto done
 @echo   -h host       Specify the hostname for this Solr instance
 @echo.
 @echo   -p port       Specify the port to start the Solr HTTP listener on; default is 8983
-@echo "                  The specified port (SOLR_PORT) will also be used to determine the stop port"
-@echo "                  STOP_PORT=(\$SOLR_PORT-1000) and JMX RMI listen port RMI_PORT=(\$SOLR_PORT+10000). "
-@echo "                  For instance, if you set -p 8985, then the STOP_PORT=7985 and RMI_PORT=18985"
+@echo                   The specified port (SOLR_PORT) will also be used to determine the stop port
+@echo                   STOP_PORT=(%%SOLR_PORT%%-1000) and JMX RMI listen port RMI_PORT=(%%SOLR_PORT%%+10000).
+@echo                   For instance, if you set -p 8985, then the STOP_PORT=7985 and RMI_PORT=18985
 @echo.
 @echo   -d dir        Specify the Solr server directory; defaults to server
 @echo.

--- a/solr/core/src/java/org/apache/solr/cli/StatusTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/StatusTool.java
@@ -78,8 +78,10 @@ public class StatusTool extends ToolBase {
   public void runImpl(CommandLine cli) throws Exception {
     // Override the default help behaviour to put out a customized message that omits the internally
     // focused Options.
-    if (cli.getOptions().length == 0 || cli.getArgs().length == 0 || cli.hasOption("h")) {
-      new HelpFormatter().printHelp("status", new Options());
+    if ((cli.getOptions().length == 0 && cli.getArgs().length == 0) || cli.hasOption("h")) {
+      final Options options = new Options();
+      getOptions().forEach(options::addOption);
+      new HelpFormatter().printHelp("status", options);
       return;
     }
 


### PR DESCRIPTION
All arg handling will be going through SolrCLI in v10

Updated in round 1:
* create
* create_core
* create_collection
* delete
* healthcheck
* status


I'm still not able to run the BATS tests locally, so all of the testing for this has been before/after manual testing. Commands still worked as expected (e.g. creating/deleting cores, printing out per-command usage instructions), but I'm not confident enough in my understanding of the whole application yet that I'd consider my solo testing sufficient.

---

## Work remaining


~`status` is giving me trouble, when I pass it into `run_solrcli` I get stop getting the expected results from `solr.cmd status` (e.g.):~

