### PR TITLE
Remove status usage commands

### DIFF
--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -279,7 +279,7 @@ IF "%SCRIPT_CMD%"=="create_collection" goto run_solrcli
 IF "%SCRIPT_CMD%"=="delete" goto run_solrcli
 IF  "%SCRIPT_CMD%"=="zk" goto zk_usage
 IF "%SCRIPT_CMD%"=="auth" goto auth_usage
-IF "%SCRIPT_CMD%"=="status" goto status_usage
+IF "%SCRIPT_CMD%"=="status" goto run_solrcli
 goto done
 
 :script_usage
@@ -362,14 +362,6 @@ goto done
 @echo   -v and -q     Verbose (-v) or quiet (-q) logging. Sets default log level to DEBUG or WARN instead of INFO
 @echo.
 @echo   -V/-verbose   Verbose messages from this script
-@echo.
-goto done
-
-:status_usage
-@echo.
-@echo Usage: solr status
-@echo.
-@echo   NOTE: This command will show the status of all running Solr servers
 @echo.
 goto done
 
@@ -1324,10 +1316,11 @@ for /f "usebackq" %%i in (`dir /b "%SOLR_TIP%\bin" ^| findstr /i "^solr-.*\.port
           @echo.
           set has_info=1
           echo Found Solr process %%k running on port !SOME_SOLR_PORT!
+          REM Passing in %2 (-h or -help) directly is captured by a custom help path for usage output
           "%JAVA%" %SOLR_SSL_OPTS% %AUTHC_OPTS% %SOLR_ZK_CREDS_AND_ACLS% -Dsolr.install.dir="%SOLR_TIP%" ^
             -Dlog4j.configurationFile="file:///%DEFAULT_SERVER_DIR%\resources\log4j2-console.xml" ^
             -classpath "%DEFAULT_SERVER_DIR%\solr-webapp\webapp\WEB-INF\lib\*;%DEFAULT_SERVER_DIR%\lib\ext\*" ^
-            org.apache.solr.cli.SolrCLI status -solrUrl !SOLR_URL_SCHEME!://%SOLR_TOOL_HOST%:!SOME_SOLR_PORT!/solr
+            org.apache.solr.cli.SolrCLI status -solrUrl !SOLR_URL_SCHEME!://%SOLR_TOOL_HOST%:!SOME_SOLR_PORT!/solr %2
           @echo.
         )
       )
@@ -1666,7 +1659,7 @@ IF "%FIRST_ARG%"=="start" (
 ) ELSE IF "%FIRST_ARG%"=="auth" (
   goto auth_usage
 ) ELSE IF "%FIRST_ARG%"=="status" (
-  goto status_usage
+  goto run_solrcli
 ) ELSE (
   goto script_usage
 )

--- a/solr/core/src/java/org/apache/solr/cli/StatusTool.java
+++ b/solr/core/src/java/org/apache/solr/cli/StatusTool.java
@@ -78,7 +78,7 @@ public class StatusTool extends ToolBase {
   public void runImpl(CommandLine cli) throws Exception {
     // Override the default help behaviour to put out a customized message that omits the internally
     // focused Options.
-    if ((cli.getOptions().length == 0 && cli.getArgs().length == 0) || cli.hasOption("h")) {
+    if (cli.hasOption("h") || cli.hasOption("help")) {
       final Options options = new Options();
       getOptions().forEach(options::addOption);
       new HelpFormatter().printHelp("status", options);


### PR DESCRIPTION
I'm not actually sure how to trigger two paths:

* this [:usage](https://github.com/epugh/solr/compare/SOLR-16829...Willdotwhite:solr:feature/remove_status_usage_commands?expand=1#diff-118de7ae5d9fc032e479321cb4d3ee62ceb68e9f3c845292b44c5e14c0f769cfR282) condition
* this [:invalid_cmd_line](https://github.com/epugh/solr/compare/SOLR-16829...Willdotwhite:solr:feature/remove_status_usage_commands?expand=1#diff-118de7ae5d9fc032e479321cb4d3ee62ceb68e9f3c845292b44c5e14c0f769cfR1662) condition

Any advice? I'm not sure we actually need these, but can't remove until I know for definite.

---

### Output

#### status 

```
PS C:\Users\Will\Projects\solr\solr\packaging\build\dev\bin> .\solr.cmd status      

Found Solr process 1820 running on port 8983
{
  "solr_home":"C:\\Users\\Will\\Projects\\solr\\solr\\packaging\\build\\dev\\server\\solr",
  "version":"10.0.0-SNAPSHOT 26168f57d2f839535f98c93e22aee82024199794 [snapshot build, details omitted]",
  "startTime":"Thu Jun 29 19:28:03 BST 2023",
  "uptime":"0 days, 0 hours, 37 minutes, 6 seconds",
  "memory":"226.5 MB (%44.2) of 512 MB"}
```

#### status -h

```
PS C:\Users\Will\Projects\solr\solr\packaging\build\dev\bin> .\solr.cmd status -h

Found Solr process 1820 running on port 8983
usage: status
 -help                 Print this message
 -maxWaitSecs <SECS>   Wait up to the specified number of seconds to see
                       Solr running.
 -solrUrl <URL>        Property set by calling scripts, not meant for user
                       configuration.
 -verbose              Enable more verbose command output.
```

#### status -help

```
PS C:\Users\Will\Projects\solr\solr\packaging\build\dev\bin> .\solr.cmd status -help

Found Solr process 1820 running on port 8983
usage: status
 -help                 Print this message
...
```

### Nonsense

#### Invalid %2 parameter (ignored)
```
PS C:\Users\Will\Projects\solr\solr\packaging\build\dev\bin> .\solr.cmd status foobar -help

Found Solr process 1820 running on port 8983
{
  "solr_home":"C:\\Users\\Will\\Projects\\solr\\solr\\packaging\\build\\dev\\server\\solr",
  ...}
```

#### Invalid flag (triggers usage)
```
PS C:\Users\Will\Projects\solr\solr\packaging\build\dev\bin> .\solr.cmd status -wibble

Found Solr process 1820 running on port 8983
Failed to parse command-line arguments due to: Unrecognized option: -wibble
usage: status
 -help                 Print this message
...
```