### PR TITLE
Support help flags in SolrCLI

### DIFF
--- a/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/cli/SolrCLI.java
@@ -121,7 +121,10 @@ public class SolrCLI implements CLIO {
 
   /** Runs a tool. */
   public static void main(String[] args) throws Exception {
-    if (args == null || args.length == 0 || args[0] == null || args[0].trim().length() == 0) {
+    final boolean hasNoCommand = args == null || args.length == 0 || args[0] == null || args[0].trim().length() == 0;
+    final boolean isHelpCommand = Arrays.asList("-h", "--help", "/?").contains(args[0]);
+
+    if (hasNoCommand || isHelpCommand) {
       printHelp();
       exit(1);
     }


### PR DESCRIPTION
Addresses concerns [here](https://github.com/apache/solr/pull/1759#issuecomment-1637154270):

```powershell
PS C:\Users\Will\Projects\solr\solr\packaging\build\dev\bin> .\solr.cmd -h    
Usage: solr COMMAND OPTIONS
...

PS C:\Users\Will\Projects\solr\solr\packaging\build\dev\bin> .\solr.cmd --help
Usage: solr COMMAND OPTIONS
...

PS C:\Users\Will\Projects\solr\solr\packaging\build\dev\bin> .\solr.cmd /?    
Usage: solr COMMAND OPTIONS
...
```
